### PR TITLE
Update docker-teranode.yml to enable user specified HOST_IP via env variable

### DIFF
--- a/base/docker-teranode.yml
+++ b/base/docker-teranode.yml
@@ -34,8 +34,7 @@ services:
     entrypoint: [ "/app/entrypoint.sh" ]
     command: [ "-asset=1" ]
     ports:
-      - "127.0.0.1:8090:8090" # expose the blockchain viewer to localhost
-    depends_on:
+      - "${HOST_IP:-127.0.0.1}:8090:8090" # expose the blockchain viewer to localhost.
       blockchain:
         condition: service_healthy
     healthcheck:
@@ -148,7 +147,7 @@ services:
     entrypoint: [ "/app/entrypoint.sh" ]
     command: [ "-p2p=1" ]
     ports:
-      - "127.0.0.1:9905:9905" # P2P port - either TCP to it or remove 127.0.0.1: to make it available on all interfaces
+      - "${HOST_IP:-127.0.0.1}:9905:9905" # P2P port - set HOST_IP=0.0.0.0 in .env to make it available on all interfaces
     depends_on:
       blockchain:
         condition: service_healthy


### PR DESCRIPTION
Enables user specified HOST_IP via env variable.  

Current implementation requires direct editing of a file that is likely to change.