### PR TITLE
Update teranode to v0.11.5

### DIFF
--- a/base/docker-teranode.yml
+++ b/base/docker-teranode.yml
@@ -1,6 +1,6 @@
 x-teranode-base:
   &teranode-base
-  image: ghcr.io/bsv-blockchain/teranode:v0.11.4
+  image: ghcr.io/bsv-blockchain/teranode:v0.11.5
   networks:
     - teranode-network
   volumes:


### PR DESCRIPTION
This pull request updates the Teranode Docker image to a newer version in the `base/docker-teranode.yml` file.

- Upgraded the Teranode Docker image from version `v0.11.4` to `v0.11.5` to ensure the deployment uses the latest release.