### PR TITLE
Update teranode to v0.11.15

### DIFF
--- a/base/docker-teranode.yml
+++ b/base/docker-teranode.yml
@@ -1,6 +1,6 @@
 x-teranode-base:
   &teranode-base
-  image: ghcr.io/bsv-blockchain/teranode:v0.11.13
+  image: ghcr.io/bsv-blockchain/teranode:v0.11.15
   networks:
     - teranode-network
   volumes:


### PR DESCRIPTION
This pull request updates the Docker image version for Teranode in the `base/docker-teranode.yml` file to ensure the service uses the latest release.

* Docker image version for Teranode updated from `v0.11.13` to `v0.11.15` in `base/docker-teranode.yml` to use the latest features and bug fixes.