### PR TITLE
Update README.md to remove stale NGROK links

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Automated setup for Teranode on the Teratestnet network using Docker Compose.
 ## Prerequisites
 
 - **Docker** and **Docker Compose** installed
-- **Ngrok** (if using default setup) - See [NGROK_PREREQUISITES.md](./NGROK_PREREQUISITES.md)
+- **Ngrok** (if using default setup) - See [SETUP_GUIDE](./docs/SETUP_GUIDE.md#example-1-standard-setup-with-ngrok)
 - 32GB+ RAM, 40GB+ disk space
 - Linux, macOS, or Windows with WSL2
 
@@ -54,7 +54,6 @@ docker compose down -v
 
 For detailed setup instructions, configuration options, troubleshooting, and advanced usage, see:
 - [Complete Setup Guide](./docs/SETUP_GUIDE.md)
-- [Ngrok Prerequisites](./NGROK_PREREQUISITES.md)
 
 ## Service Endpoints
 


### PR DESCRIPTION
This pull request updates the `README.md` to improve documentation consistency and clarity regarding Ngrok prerequisites. The main change is to reference the consolidated setup guide for Ngrok instructions, removing the separate Ngrok prerequisites link.

**Documentation improvements:**

* Updated the Ngrok prerequisite link to point to the relevant section in the main setup guide (`docs/SETUP_GUIDE.md#example-1-standard-setup-with-ngrok`) instead of the old `NGROK_PREREQUISITES.md` file.
* Removed the redundant "Ngrok Prerequisites" link from the list of setup resources, streamlining the documentation.

Fixes #40 